### PR TITLE
Part 1: sort and iterate instead of nesting loops

### DIFF
--- a/AoC Code.ipynb
+++ b/AoC Code.ipynb
@@ -9,7 +9,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -28,34 +28,61 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [
     {
      "output_type": "stream",
      "name": "stdout",
      "text": [
-      "[1124] [896]\n[1007104]\n"
+      "[896] [1124]\n",
+      "[1007104]\n"
      ]
     }
    ],
    "source": [
-    "def getPairs(arr, sum): \n",
-    "    n = len(arr)\n",
-    "    \n",
+    "def getPairs(arr, sum):\n",
+    "    N = len(arr)\n",
+    "    l = 0\n",
+    "    r = N - 1\n",
     "\n",
-    "    # Cycle through all pairs and check sum \n",
-    "    for i in range(0, n): \n",
-    "        for j in range(i + 1, n): \n",
-    "            if arr[i] + arr[j] == sum: \n",
-    "                ans1=arr[i]\n",
-    "                ans2=arr[j]\n",
-    "                print(arr[i],arr[j])\n",
+    "    # sort array\n",
+    "    arr = sorted(arr, key=(lambda xs: xs[0]))\n",
     "\n",
-    "    return ans1,ans2\n",
+    "    # invariant I: only elements in arr[l..r) can be part of the correct pair\n",
+    "    #              && l < r\n",
+    "    #\n",
+    "    # This means we only need to consider elements in arr[l..r).\n",
+    "    while (l < r):\n",
     "\n",
-    "ans1,ans2=getPairs(arr,2020)\n",
-    "print(ans1*ans2)"
+    "        # I && l < r\n",
+    "        lr_sum = arr[l] + arr[r]\n",
+    "\n",
+    "        if lr_sum < sum:\n",
+    "            # arr[l] cannot be part of the correct pair. Since arr is sorted,\n",
+    "            # any pair containing arr[l] will have even smaller sum. Hence, I\n",
+    "            # is maintained.\n",
+    "            l += 1\n",
+    "\n",
+    "        elif lr_sum > sum:\n",
+    "            # arr[r] cannot be part of the correct pair. Since arr is sorted,\n",
+    "            # any pair containing arr[r] will have even larger sum. Hence, I\n",
+    "            # is maintained.\n",
+    "            r -= 1\n",
+    "\n",
+    "        else:\n",
+    "            # found the correct pair, print and return\n",
+    "            print(arr[l], arr[r])\n",
+    "            return arr[l], arr[r]\n",
+    "\n",
+    "    # I && l == r => no correct pair in arr[0..N)\n",
+    "    raise Exception(\"Could not find pair\")\n",
+    "\n",
+    "try:\n",
+    "    ans1, ans2 = getPairs(arr, 2020)\n",
+    "    print(ans1 * ans2)\n",
+    "except Exception as e:\n",
+    "    print(e)"
    ]
   },
   {
@@ -69,11 +96,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
       "text/plain": [
        "array([  24,  465,  539,  812,  896, 1124, 1149, 1207, 1215, 1217, 1222,\n",
@@ -97,8 +123,9 @@
        "       2009, 2010], dtype=int64)"
       ]
      },
+     "execution_count": 3,
      "metadata": {},
-     "execution_count": 33
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -111,7 +138,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
The original algorithm for finding a pair has O(n^2) complexity with its nested loops.

This pull request reimplements this function by

1. Sorting the array → O(n log n)
2. Maintaining bounds `l`, `r` for feasible candidates for the pair `arr[l..r)`, and reducing it until we find the correct pair → O(n)

Correctness is shown using invariants in comments in the code.

---

*Aside.* The diff is noisy due to the notebook being committed with run information. I have followed this convention; however during testing I reran the entire notebook, hence mild differences may remain.

*Testing.* This was tested *only on the data in the notebook*, with `pandas==1.1.4` and python 3.8.5.